### PR TITLE
Enabled display of all subjects tutored to students on View-Tutor-Info

### DIFF
--- a/src/pages/ViewTutorInfo.js
+++ b/src/pages/ViewTutorInfo.js
@@ -47,11 +47,7 @@ function LeftStats({ tutor, tutorId }) {
     const updateTutorStatus = (event) => {
         updateTutor({ ...tutor, id: tutorId, status: event.target.value })
     }
-    // function countTutees(tutorId) {
-    //     return tutees.filter(student => student.tutorId === tutorId).length;
-    // }
 
-    const numStudents = Object.keys(tutor.students).length
 
     return <>
         <div className="tutor-stats-parent">
@@ -79,13 +75,13 @@ function LeftStats({ tutor, tutorId }) {
             <a href={"mailto:" + tutor.email}><span className="email-small-text">SEND AN EMAIL</span></a>
             <br></br>
             <br></br>
-            <b>Number of Students: </b> {Object.keys(tutor.students ?? {}).length}
+            <b>Number of Students: </b> {(tutor.students ? tutor.students : {}).length}
             <br></br>
             <br></br>
             <b>Availibility:</b>
             <br />
 
-            <Availability person={tutor} />
+            {/* <Availability person={tutor} />  */}
         </div>
     </>
 }
@@ -98,6 +94,7 @@ function AvailabilityChart() {
     );
 }
 function RightStats({ tutor }) {
+    
     const [showEditors, setShowEditors] = useState(false)
     // Temporarily add the specific student ID for testing purposes
     const [studentData, setStudentData] = useState({})
@@ -107,7 +104,7 @@ function RightStats({ tutor }) {
     const { data: student, isError, isLoading } = useGetStudentByIdQuery(newStudentId)
 
     useEffect(() => {
-        if(tutor.students.length !== 0) {
+        if(tutor.students) {
             tutor.students.map((studentId, index) => {
                 setNewStudentId(String(studentId))
             })
@@ -127,11 +124,8 @@ function RightStats({ tutor }) {
         const docRef = doc(db, "students", studentId)
         const docSnap = await getDoc(docRef)
         if (docSnap.exists()) {
-            if (studentId in tutor.students && 'subjectsTutored' in tutor.students[studentId]) { //must retrieve subjectsTutored from studentIds since not included in student object 
-                addToStudentData({ [studentId]: { "name": student.firstName + " " + student.lastName, "age": student.age, "grade": student.grade, "subjectsTutored": tutor.students[studentId].subjectsTutored } })
-            }
-            else {
-                addToStudentData({ [studentId]: { "name": student.firstName + " " + student.lastName, "age": student.age, "grade": student.grade } })
+            if (tutor.students && studentId in tutor.students) {  
+                addToStudentData({ [studentId]: { "name": student.firstName + " " + student.lastName, "age": student.age, "grade": student.grade, "subjectsTutored": getAllSubjects(tutor.students[studentId]) } })
             }
         } else {
             alert(String(studentId) + " not found")
@@ -148,6 +142,22 @@ function RightStats({ tutor }) {
     //the input in the 'Add Student' text field in Edit Students
     const [addStudentInput, setAddStudentInput] = useState("")
 
+    function getAllSubjects(personData) {
+        if (!personData) {
+          return "";
+        }
+      
+        const allSubjects = [];
+        const subjectCategories = ["mathSubjects", "scienceSubjects", "englishSubjects", "socialStudiesSubjects", "miscSubjects", "otherSubjects"];
+      
+        for (const category of subjectCategories) {
+          if (Array.isArray(personData[category]) && personData[category].length > 0) {
+            allSubjects.push(...personData[category]);
+          }
+        }
+      
+        return allSubjects.join(", ");
+      }
 
     return (
         <div className="tutor-right-stats">
@@ -162,12 +172,12 @@ function RightStats({ tutor }) {
                     </tr>
                 </thead>
                 <tbody>
-                {Object.keys(studentData).map((name) => (
-                    <tr key={name}>
-                        <td>{name ? name : "N/A"}</td>
-                        <td>{studentData[name].age}</td>
-                        <td>{studentData[name].age}</td>
-                        <td>{studentData[name].age}</td>
+                {Object.keys(studentData).map((key) => (
+                    <tr key={key}>
+                        <td>{studentData[key].name ? studentData[key].name : "N/A"}</td>
+                        <td>{studentData[key].age}</td>
+                        <td>{studentData[key].grade}</td>
+                        <td>{studentData[key].subjectsTutored}</td>
                     </tr>
                 ))}
                 </tbody>


### PR DESCRIPTION
In this commit, I have improved the code for displaying the subjects tutored to the students with getAllSubjects() and some minor changes to other lines. However, I found three other errors which I do not know how to solve yet and need your help in:

1. Availability
Through the console in Inspect Element, I saw that there were rendering errors linked to the Availability table, specifically in the line: 
return person.availability[3 * day + time];

I commented out <Availability /> to get past this rendering error for now.

2. Some tutees not found
For some tutors, their tutee objects, their keys are alerted as 'not found,' for e.g., "2" is alerted to be not found for VivaciousWhole. This is the output of checkStudentExists. Do you know another method to check if a student actually exists given their Key?

3. Difference in Matching page tutee count and View-Tutor-Info page tutee count
'Number of Students' on the left side displays the length of tutor.students, so it should be the most reliable I think. 'Current Tutees' shows the number of students that passed checkStudentExists(). The Matching page I believe shows the students that have been hard coded in Firebase? I don't know why these differ.

Also, the current code includes the function StudentsSlider which is not being used. I did not have enough time to update the code for the Slider. I will try doing it later, maybe in a different branch.