### PR TITLE
Fix displaying subjects tutored for tutor's assigned students

### DIFF
--- a/src/pages/ViewTutorInfo.js
+++ b/src/pages/ViewTutorInfo.js
@@ -120,21 +120,35 @@ function RightStats({ tutor }) {
     }, [])
 
     const checkStudentExists = useCallback(async (studentId) => {
-        const db = getFirestore(firebaseApp)
-        const docRef = doc(db, "students", studentId)
-        const docSnap = await getDoc(docRef)
+        const db = getFirestore(firebaseApp);
+        const docRef = doc(db, "students", studentId);
+        const docSnap = await getDoc(docRef);
+
         if (docSnap.exists()) {
-            if (studentId in tutor.students) { //must retrieve subjectsTutored from studentIds since not included in student object 
-                addToStudentData({ [studentId]: { "name": student.firstName + " " + student.lastName, "grade": student.grade, "subjects": [...student.mathSubjects, ...student.scienceSubjects, ...student.englishSubjects, ...student.socialStudiesSubjects, ...student.miscSubjects, student.otherSubjects] } })
-            }
-            else {
-                addToStudentData({ [studentId]: { "name": student.firstName + " " + student.lastName, "grade": student.grade } })
+            if (studentId in tutor.students) {
+                addToStudentData({
+                    [studentId]: {
+                        name: student.firstName + " " + student.lastName,
+                        grade: student.grade,
+                        subjects:
+                            tutor.students?.[studentId]?.subjectsTutored ??
+                            tutor.students?.find?.(s => s.id === studentId)?.subjectsTutored ??
+                            []
+                    }
+                });
+            } else {
+                addToStudentData({
+                    [studentId]: {
+                        name: student.firstName + " " + student.lastName,
+                        grade: student.grade
+                    }
+                });
             }
         } else {
-            alert(String(studentId) + " not found")
-            setNewStudentId("")
+            alert(String(studentId) + " not found");
+            setNewStudentId("");
         }
-    }, [student, addToStudentData])
+    }, [student, tutor.students, addToStudentData]);
 
     useEffect(() => {
         if (!isLoading && newStudentId !== "") {
@@ -162,7 +176,11 @@ function RightStats({ tutor }) {
                     <tr key={id}>
                         <td>{id ? <Link to={`/view-student-info/${id}`}> {studentData[id].name}</Link> : "N/A"}</td>
                         <td>{studentData[id].grade}</td>
-                        <td>{studentData[id].subjects}</td>
+                        <td>
+                            {Array.isArray(studentData[id].subjects)
+                                ? studentData[id].subjects.join(", ")
+                                : studentData[id].subjects || "N/A"}
+                        </td>
                     </tr>
                 ))}
                 </tbody>


### PR DESCRIPTION
This PR fixes the "Subjects Tutored" column on the Tutor Information page.

# Changes
- Retrieve `subjectsTutored` from the tutor's `students` object instead of the student document.
- Display the subjects in the Current Tutees table.
- Preserve existing behavior when `subjectsTutored` is unavailable by falling back to an empty array.

# Testing
- Opened a tutor's information page.
- Verified the Current Tutees table loads correctly.
- Confirmed the page no longer breaks when displaying students.
- Verified the Subjects Tutored column displays available data and shows "N/A" when none exists.